### PR TITLE
Fix container issue in Lumen Module

### DIFF
--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -116,22 +116,14 @@ class Lumen extends Framework implements ActiveRecord
     }
 
     /**
-     * After step hook.
-     *
-     * @param \Codeception\Step $step
-     */
-    public function _afterStep(Step $step)
-    {
-        Facade::clearResolvedInstances();
-    }
-
-    /**
      * Initialize the Lumen framework.
      *
      * @throws ModuleConfig
      */
     protected function initializeLumen()
     {
+        Facade::clearResolvedInstances();
+
         $this->app = $this->bootApplication();
         $this->app->instance('request', new Request());
         $this->client = new LumenConnector($this->app);


### PR DESCRIPTION
In Lumen module, initializeLumen() method has been called twice on that starts. (_initialize, _before)
That causes a problem that the IoC container does not store any singleton instances which created via Facade.
Facade::clearResolvedInstance() should be called every before bootApplication().

I guess #2607 is a same problem.